### PR TITLE
Use sodium-universal instead of sodium-native

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var assert = require('nanoassert')
-var sodium = require('sodium-native')
+var sodium = require('sodium-universal')
 
 var buf = new Uint8Array(7)
 var MAX = Number.MAX_SAFE_INTEGER

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var assert = require('nanoassert')
-var sodium = require('sodium-universal')
+var sodium = require('sodium-javascript')
 
 var buf = new Uint8Array(7)
 var MAX = Number.MAX_SAFE_INTEGER

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "nanoassert": "^1.1.0",
     "randombytes": "^2.0.3",
-    "sodium-native": "^3.1.1"
+    "sodium-universal": "^3.0.4"
   },
   "scripts": {},
   "repository": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "nanoassert": "^1.1.0",
     "randombytes": "^2.0.3",
-    "sodium-universal": "^3.0.4"
+    "sodium-javascript": "github:okdistribute/sodium-javascript"
   },
   "scripts": {},
   "repository": {

--- a/statistic-test.js
+++ b/statistic-test.js
@@ -1,4 +1,4 @@
-var sodium = require('sodium-native')
+var sodium = require('sodium-universal')
 var rand = require('.')
 
 var len = 23

--- a/verify-readle.js
+++ b/verify-readle.js
@@ -1,4 +1,4 @@
-var sodium = require('sodium-native')
+var sodium = require('sodium-universal')
 var buf = Buffer.alloc(8).fill(0xff)
 
 var max = ((((buf[6] & 0b00011111) << 16) | (buf[5] << 8) | (buf[4])) >>> 0) * 0x100000000 + // 21 bits, shifted left 32 bits


### PR DESCRIPTION
Hi, thanks for this package!

Was just trying to use it in the browser and came across this -- I wonder if there is a reason not to use sodium-universal instead for easy browser support?

Thanks for taking a look